### PR TITLE
Fix failing tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 npm-debug.log
 lib
+.tern-port

--- a/src/connect-middleware.js
+++ b/src/connect-middleware.js
@@ -9,7 +9,7 @@ export default function (setupTenant) {
     return async function middleware (req, res, next) {
       const tenantId = req.header(header);
       if (typeof tenantId === 'undefined') {
-        return next(`Missing ${header} header`);
+        return res.status(500).send(`Missing ${header} header\n`);
       }
 
       req.knex = await setupTenant(baseKnex, tenantId);


### PR DESCRIPTION
The test for throwing an error if `x-client-id` is not set was failing because it was expecting an plain text response, and was receiving a html response