### PR TITLE
Fix unit test

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "babel-runtime": "^6.6.1",
     "debug": "^2.2.0",
+    "knex": "^0.11.10",
     "promise-async-cache": "^1.0.0"
   },
   "devDependencies": {

--- a/spec/connect-middleware.spec.js
+++ b/spec/connect-middleware.spec.js
@@ -13,6 +13,16 @@ describe('connect-middleware with default settings', function() {
 
     app.use(knextancy.middleware(knex));
 
+    app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
+      console.error(err.stack || err); // eslint-disable-line no-console
+
+      if (err) {
+        return res.status(500).send(err);
+      }
+
+      return next();
+    });
+
     app.get('/', function (req, res) {
       req.knex.select().from('$_users').then(function (users) {
         res.send(users);
@@ -51,7 +61,7 @@ describe('connect-middleware with default settings', function() {
         .end(function (err, res) {
           if (err) { return done(err); }
 
-          expect(res.text).to.eql('Missing x-client-id header\n');
+          expect(res.text).to.eql('Missing x-client-id header');
 
           done();
         });


### PR DESCRIPTION
The default Express error handler is returning the error formated in HTML and the test was expexting the error in plain text